### PR TITLE
Create copy-markdown-url-and-title.applescript

### DIFF
--- a/commands/browsing/copy-markdown-url-and-title.applescript
+++ b/commands/browsing/copy-markdown-url-and-title.applescript
@@ -1,0 +1,63 @@
+#!/usr/bin/osascript
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Copy Markdown URL and Title
+# @raycast.mode silent
+#
+# Optional parameters:
+# @raycast.packageName Copy Markdown URL and Title
+# @raycast.icon 🔗
+#
+# Documentation:
+# @raycast.description Copy URL and title from the current browser as markdown. Currently supported browsers are Brave Browser, Opera, Chrome, Vivaldi, Firefox, Safari
+# @raycast.author Jakub Chodorowicz
+# @raycast.authorURL https://github.com/chodorowicz
+
+set the otherBrowsers to {"Firefox", "Safari"}
+set the chromiumBrowsers to {"Google Chrome","Brave Browser","Opera", "Vivaldi"}
+
+tell application "System Events"
+	set frontmostProcess to first process where it is frontmost
+	set appName to name of frontmostProcess
+end tell
+
+if appName is in chromiumBrowsers then
+	using terms from application "Google Chrome"
+		tell application appName
+			tell active tab of front window
+				set linkTitle to Title
+				set linkUrl to URL
+			end tell
+		end tell
+	end using terms from
+end if
+
+if appName is equal to "Safari" then
+	tell application "Safari" to tell document 1
+		set linkTitle to name
+		set linkUrl to URL
+	end tell
+end if
+
+if appName is equal to "Firefox" then
+	tell application "Firefox"
+		set linkTitle to name of front window
+
+		tell application "System Events"
+			tell process "firefox"
+				keystroke "l" using {command down}
+				delay 0.1
+				keystroke "c" using {command down}
+				delay 0.1
+			end tell
+		end tell
+
+		set linkUrl to get the clipboard
+	end tell
+end if
+
+if appName is in otherBrowsers or appName is in chromiumBrowsers then
+	set the clipboard to "[" & linkTitle & "](" & linkUrl & ")"
+	log "Markdown link copied from " & appName
+end if


### PR DESCRIPTION
## Description

This script copies url and title in markdown format from various browsers. Currently supported browsers:
"Firefox", "Safari",  "Google Chrome", "Brave Browser", "Opera", "Vivaldi"

<!-- Please write a short summary for this change. If it's a new script command, explain what it does. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New script command
- [ ] Bug fix
- [ ] Improvement of an existing script
- [ ] Documentation update
- [ ] Toolkit change
- [ ] Other (Specify)

## Screenshot

<!-- If it's a new script command, please include a screenshot or a GIF of how it works. -->

![image-2022-01-23-mzoUPEnk](https://user-images.githubusercontent.com/119451/150691133-0ccbbbfe-83a9-4578-afc2-29ef528a1973.jpg)

![image-2022-01-23-XliuzMXI](https://user-images.githubusercontent.com/119451/150691129-83a4b825-bafb-4bee-b535-a7f34cee5de2.jpg)

results: `[Comparing master...copy-markdown-url-and-title · chodorowicz/script-commands](https://github.com/chodorowicz/script-commands/compare/master...copy-markdown-url-and-title?quick_pull=1)` copied to the clipboardd

## Checklist

- [x] I have read [Contribution Guidelines](https://github.com/raycast/script-commands/blob/master/CONTRIBUTING.md)